### PR TITLE
Add :JacVec and :HessVec on features_available

### DIFF
--- a/src/nlp_to_mpb.jl
+++ b/src/nlp_to_mpb.jl
@@ -16,7 +16,8 @@ end
 MathProgBase.initialize(::NLPModelEvaluator, requested_features) = nothing
 
 # SAutodetect?
-MathProgBase.features_available(::NLPModelEvaluator) = [:Grad, :Jac, :Hess]
+MathProgBase.features_available(::NLPModelEvaluator) = [:Grad, :Jac, :JacVec, :HessVec, :Hess]
+MathProgBase.features_available(::NLPModelEvaluator{NLPModels.ADNLPModel}) = [:Grad, :Jac, :Hess]
 
 MathProgBase.eval_f(d::NLPModelEvaluator, x) = obj(d.nlp, x)
 


### PR DESCRIPTION
This redefines the default features to have all.
Essentially because I want `CUTEst` to not depend on `JuMPNLPModels` in the future :)

Models that can't give all functions efficiently must redefine `features_available`, such as `AmplNLReader`.